### PR TITLE
coins22: 基礎科目(選択)が上限を超えて全体の単位数に加算されないようにする

### DIFF
--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -7,6 +7,22 @@ pub trait Credits {
   fn is_ok(&self) -> bool;
 }
 
+pub trait DynCredits: Credits {
+  fn clone_boxed(&self) -> Box<dyn DynCredits>;
+}
+
+impl<T> DynCredits for T where T: Credits + Clone + 'static {
+  fn clone_boxed(&self) -> Box<dyn DynCredits> {
+    Box::new(Clone::clone(self))
+  }
+}
+
+impl Clone for Box<dyn DynCredits> {
+  fn clone(&self) -> Self {
+    self.clone_boxed()
+  }
+}
+
 #[derive(Clone, Debug)]
 pub struct CreditsInfo {
   pub name: String,
@@ -151,11 +167,11 @@ impl Credits for CreditsPE {
   }
 }
 
-//#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct CreditsData {
   pub msg_prefix: String,
   pub name: String,
-  pub credits_list: Vec<Box<dyn Credits>>,
+  pub credits_list: Vec<Box<dyn DynCredits>>,
   pub pattern: CreditsPattern,
 }
 

--- a/src/pattern/coins22.rs
+++ b/src/pattern/coins22.rs
@@ -148,13 +148,13 @@ pub fn check(config: &config::Config) -> Result<Vec<Box<dyn Credits>>> {
     msg_prefix: "--------- ".to_string(),
     name: "専門必修".to_string(),
     credits_list: vec![
-      Box::new(専門必修実験.clone()),
-      Box::new(専門必修卒業研究.clone()),
-      Box::new(専門必修専門語学.clone()),
+      Box::new(専門必修実験),
+      Box::new(専門必修卒業研究),
+      Box::new(専門必修専門語学),
     ],
     pattern: CreditsPattern::Only(16),
   };
-  lst.push(Box::new(専門必修));
+  lst.push(Box::new(専門必修.clone()));
 
   lst.push(Box::new(専門選択1.clone()));
   lst.push(Box::new(専門選択2.clone()));
@@ -162,10 +162,10 @@ pub fn check(config: &config::Config) -> Result<Vec<Box<dyn Credits>>> {
   let 専門選択 = CreditsData {
     msg_prefix: "--------- ".to_string(),
     name: "専門選択".to_string(),
-    credits_list: vec![Box::new(専門選択1.clone()), Box::new(専門選択2.clone())],
+    credits_list: vec![Box::new(専門選択1), Box::new(専門選択2)],
     pattern: CreditsPattern::Only(34),
   };
-  lst.push(Box::new(専門選択));
+  lst.push(Box::new(専門選択.clone()));
 
   lst.push(Box::new(専門基礎必修.clone()));
 
@@ -178,39 +178,38 @@ pub fn check(config: &config::Config) -> Result<Vec<Box<dyn Credits>>> {
     msg_prefix: "--------- ".to_string(),
     name: "専門基礎選択".to_string(),
     credits_list: vec![
-      Box::new(専門基礎選択1.clone()),
-      Box::new(専門基礎選択2.clone()),
-      Box::new(専門基礎選択3.clone()),
-      Box::new(専門基礎選択4.clone()),
+      Box::new(専門基礎選択1),
+      Box::new(専門基礎選択2),
+      Box::new(専門基礎選択3),
+      Box::new(専門基礎選択4),
     ],
     pattern: CreditsPattern::Only(26),
   };
-  lst.push(Box::new(専門基礎選択));
+  lst.push(Box::new(専門基礎選択.clone()));
 
   lst.push(Box::new(基礎共通必修総合科目.clone()));
   lst.push(Box::new(基礎共通必修外国語.clone()));
   let 基礎共通必修体育 = CreditsData {
     msg_prefix: String::new(),
     name: "基礎共通必修体育".to_string(),
-    credits_list: vec![Box::new(基礎体育.clone()), Box::new(応用体育.clone())],
+    credits_list: vec![Box::new(基礎体育), Box::new(応用体育)],
     pattern: CreditsPattern::Only(2),
   };
-  lst.push(Box::new(基礎共通必修体育));
+  lst.push(Box::new(基礎共通必修体育.clone()));
   lst.push(Box::new(基礎共通必修情報.clone()));
 
   let 基礎共通必修 = CreditsData {
     msg_prefix: "--------- ".to_string(),
     name: "基礎共通必修".to_string(),
     credits_list: vec![
-      Box::new(基礎共通必修総合科目.clone()),
-      Box::new(基礎体育.clone()),
-      Box::new(応用体育.clone()),
-      Box::new(基礎共通必修外国語.clone()),
-      Box::new(基礎共通必修情報.clone()),
+      Box::new(基礎共通必修総合科目),
+      Box::new(基礎共通必修体育),
+      Box::new(基礎共通必修外国語),
+      Box::new(基礎共通必修情報),
     ],
     pattern: CreditsPattern::Only(12),
   };
-  lst.push(Box::new(基礎共通必修));
+  lst.push(Box::new(基礎共通必修.clone()));
 
   lst.push(Box::new(基礎共通選択1.clone()));
   lst.push(Box::new(基礎共通選択2.clone()));
@@ -219,12 +218,12 @@ pub fn check(config: &config::Config) -> Result<Vec<Box<dyn Credits>>> {
     msg_prefix: "--------- ".to_string(),
     name: "基礎共通選択".to_string(),
     credits_list: vec![
-      Box::new(基礎共通選択1.clone()),
-      Box::new(基礎共通選択2.clone()),
+      Box::new(基礎共通選択1),
+      Box::new(基礎共通選択2),
     ],
     pattern: CreditsPattern::Range(1, 5),
   };
-  lst.push(Box::new(基礎共通選択));
+  lst.push(Box::new(基礎共通選択.clone()));
 
   lst.push(Box::new(基礎関連選択1.clone()));
   lst.push(Box::new(基礎関連選択2.clone()));
@@ -233,73 +232,54 @@ pub fn check(config: &config::Config) -> Result<Vec<Box<dyn Credits>>> {
     msg_prefix: "--------- ".to_string(),
     name: "基礎関連選択".to_string(),
     credits_list: vec![
-      Box::new(基礎関連選択1.clone()),
-      Box::new(基礎関連選択2.clone()),
+      Box::new(基礎関連選択1),
+      Box::new(基礎関連選択2),
     ],
     pattern: CreditsPattern::Range(6, 10),
   };
-  lst.push(Box::new(基礎関連選択));
+  lst.push(Box::new(基礎関連選択.clone()));
+
+  let 基礎選択: CreditsData = CreditsData {
+    msg_prefix: "--------- ".to_string(),
+    name: "基礎選択".to_string(),
+    credits_list: vec![
+      Box::new(基礎共通選択),
+      Box::new(基礎関連選択),
+    ],
+    pattern: CreditsPattern::Top(11),
+  };
+  //lst.push(Box::new(基礎選択.clone()));
 
   let 必修 = CreditsData {
     msg_prefix: "***** ".to_string(),
     name: "必修".to_string(),
     credits_list: vec![
-      Box::new(専門必修実験.clone()),
-      Box::new(専門必修卒業研究.clone()),
-      Box::new(専門必修専門語学.clone()),
-      Box::new(専門基礎必修.clone()),
-      Box::new(基礎共通必修総合科目.clone()),
-      Box::new(基礎体育.clone()),
-      Box::new(応用体育.clone()),
-      Box::new(基礎共通必修外国語.clone()),
-      Box::new(基礎共通必修情報.clone()),
+      Box::new(専門必修),
+      Box::new(専門基礎必修),
+      Box::new(基礎共通必修),
     ],
     pattern: CreditsPattern::Only(54),
   };
-  lst.push(Box::new(必修));
+  lst.push(Box::new(必修.clone()));
 
   let 選択 = CreditsData {
     msg_prefix: "***** ".to_string(),
     name: "選択".to_string(),
     credits_list: vec![
-      Box::new(専門選択1.clone()),
-      Box::new(専門選択2.clone()),
-      Box::new(専門基礎選択1.clone()),
-      Box::new(専門基礎選択2.clone()),
-      Box::new(専門基礎選択3.clone()),
-      Box::new(専門基礎選択4.clone()),
-      Box::new(基礎共通選択1.clone()),
-      Box::new(基礎共通選択2.clone()),
-      Box::new(基礎関連選択1.clone()),
-      Box::new(基礎関連選択2.clone()),
+      Box::new(専門選択),
+      Box::new(専門基礎選択),
+      Box::new(基礎選択),
     ],
     pattern: CreditsPattern::Only(71),
   };
-  lst.push(Box::new(選択));
+  lst.push(Box::new(選択.clone()));
 
   let 卒業 = CreditsData {
     msg_prefix: "!!!!!!!!!! ".to_string(),
     name: "全体".to_string(),
     credits_list: vec![
-      Box::new(専門必修実験),
-      Box::new(専門必修卒業研究),
-      Box::new(専門必修専門語学),
-      Box::new(専門基礎必修),
-      Box::new(基礎共通必修総合科目),
-      Box::new(基礎体育),
-      Box::new(応用体育),
-      Box::new(基礎共通必修外国語),
-      Box::new(基礎共通必修情報),
-      Box::new(専門選択1),
-      Box::new(専門選択2),
-      Box::new(専門基礎選択1),
-      Box::new(専門基礎選択2),
-      Box::new(専門基礎選択3),
-      Box::new(専門基礎選択4),
-      Box::new(基礎共通選択1),
-      Box::new(基礎共通選択2),
-      Box::new(基礎関連選択1),
-      Box::new(基礎関連選択2),
+      Box::new(必修),
+      Box::new(選択),
     ],
     pattern: CreditsPattern::Only(125),
   };


### PR DESCRIPTION
現在の実装では，基礎共通選択1～5単位および基礎関連選択6～10単位の制約と，全体の単位数の計算とが別々に行われています．そのため，例えば基礎共通選択を6単位，基礎関連選択を10単位取ると全体の単位数に16単位含まれてしまいます．履修要覧の卒業要件の表を見ると，基礎共通選択と基礎関連選択の合計は11単位を超えないようにする必要がありそうです．

このPRでは，`CreditsData`を入れ子にして，超過分を全体の単位数に算入しないように変更します．